### PR TITLE
Modified script to use with ruby-packer

### DIFF
--- a/cli/saas.rb
+++ b/cli/saas.rb
@@ -26,4 +26,4 @@ end
 
 # Now delegate to that script by spinning up a new Ruby process
 # The remaining command-line arguments (ARGV) are passed through unmodified.
-exec "ruby", script_file.to_s, *ARGV
+load script_file


### PR DESCRIPTION
There are steps to follow to create the executable file:

### Get the fork of ruby-packer that works with ruby-3.1.0 and make an executable rubyc
- Go to this [repo](https://github.com/ericbeland/ruby-packer/tree/9cad91441c36f53cf3b1d305a93fa32b4ba5863c)
- clone to your local
- run `git checkout 9cad914`
- run `bundle exec rake rubyc`
- move rubyc to /usr/local/bin `mv rubyc /usr/local/bin`

### Build the executable file for blackops
- Go to this PR
- on the root folder run this `rubyc --output=saas --root=. ./cli/saas.rb`
- move saas to /usr/local/bin `mv saas /usr/local/bin`


Now you can run commands from saas directly

saas deploy args...